### PR TITLE
fix: Clean body in cors preflight responses

### DIFF
--- a/api/src/cors.rs
+++ b/api/src/cors.rs
@@ -26,6 +26,9 @@ impl Fairing for CORS {
                 "POST, PATCH, GET, DELETE",
             ));
             response.set_header(Header::new("Access-Control-Allow-Headers", "*"));
+            // Remove body to make sure that the response is empty
+            // otherwise the response can not be treated as a valid preflight response.
+            response.set_sized_body(0, std::io::Cursor::new(Vec::new()));
         }
 
         // Take the Plugin App URL from the env variable, if set


### PR DESCRIPTION
See https://stackoverflow.com/questions/68318578/express-server-running-on-google-cloud-run-returns-502-bad-gateway-when-respondi