### PR TITLE
fix: Version management

### DIFF
--- a/.github/workflows/build-deploy-prod-ui.yml
+++ b/.github/workflows/build-deploy-prod-ui.yml
@@ -9,7 +9,6 @@ concurrency:
 env:
   NODE_VERSION: '20.x'
   API_SERVICE_URL: "https://remix-plugin-api.zksync.io"
-  VITE_VERSION: v0.6.3
   VITE_REMOTE_DEVNET_URL: "https://era-test-node.zksync.io"
 jobs:
   build-deploy-static:

--- a/README.md
+++ b/README.md
@@ -64,8 +64,11 @@ cd api
 cd hardhat_env
 yarn
 cd ..
-VITE_URL=http://localhost:3000 SERVICE_VERSION="v0.1.1" cargo run
+VITE_URL=http://localhost:3000 cargo run
 ```
+
+*Note:* By default, the crate version will be used to represent the version of the backend. It's possible to override it
+via `SERVICE_VERSION` environment variable, but it's not recommended.
 
 #### Plugin
 
@@ -81,13 +84,16 @@ pnpm install;
 Firstly, you need to define ENV variables for the server:
 
 - VITE_URL=http://localhost:3000 - the address of the UI
-- SERVICE_VERSION="v0.0.1" - the version of the back-end (should be less than version of UI)
 
 And ENV variables for the plugin:
 
 - API_SERVICE_URL="http://127.0.0.1:8000" - the address of the API
 - WALLETCONNECT_PROJECT_ID=<your_walletconnect_project_id> - the project id for WalletConnect
 - ZKSYNC_DEVNET_URL="https://zksync-devnet.nethermind.dev" - the address of the ZKsync devnet
+
+
+*Note:* By default, the package version will be used to represent the version of the plugin. It's possible to override it
+via `VITE_VERSION` environment variable, but it's not recommended.
 
 You need to be running both the server and the plugin in order to have a working environment.
 
@@ -110,7 +116,7 @@ cd api
 cd hardhat_env
 yarn
 cd ..
-VITE_URL=http://localhost:3000 SERVICE_VERSION="v0.1.1" cargo run
+VITE_URL=http://localhost:3000 cargo run
 ```
 
 or alternatively, you can run the server in watch mode (with `cargo watch`):

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "0.1.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT or APACHE 2.0"
 

--- a/api/src/handlers/utils.rs
+++ b/api/src/handlers/utils.rs
@@ -2,12 +2,14 @@ use tracing::instrument;
 
 use crate::metrics::MethodLatency;
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[instrument]
 #[get("/service_version")]
 pub async fn service_version() -> String {
     let _guard = MethodLatency::new("/service_version");
     tracing::info!("/service_version");
-    std::env::var("SERVICE_VERSION").unwrap_or_else(|_| String::from("unknown"))
+    std::env::var("SERVICE_VERSION").unwrap_or_else(|_| format!("v{VERSION}"))
 }
 
 #[instrument]

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zksync-remix-plugin",
-  "version": "0.1.0",
+  "version": "0.7.0",
   "private": true,
   "dependencies": {
     "@radix-ui/react-accordion": "^1.1.2",

--- a/plugin/vite.config.ts
+++ b/plugin/vite.config.ts
@@ -3,8 +3,12 @@ import path from 'path'
 import react from '@vitejs/plugin-react'
 import svgr from 'vite-plugin-svgr'
 import checker from 'vite-plugin-checker'
+import { execSync } from 'child_process'
 
 export default defineConfig(() => {
+  const commitHash = execSync('git rev-parse --short HEAD').toString().trimEnd();
+  process.env.VITE_COMMIT_HASH = commitHash;
+
   return {
     define: {
       'process.env': {}


### PR DESCRIPTION
Use npm package version and crate version to determine corresponding versions in UI instead of relying on env vars.