### PR TITLE
chore: update chainlink & openzeppelin versions

### DIFF
--- a/api/hardhat_env/package.json
+++ b/api/hardhat_env/package.json
@@ -18,7 +18,7 @@
     "@matterlabs/zksync-contracts": "^0.6.1",
     "@openzeppelin/contracts": "^5.2.0",
     "@openzeppelin/contracts-upgradeable": "^4.6.0",
-    "@chainlink/contracts": "^1.5.0",
+    "@chainlink/contracts": "^1.3.0",
     "@thirdweb-dev/contracts": "^3.11.2"
   }
 }

--- a/api/hardhat_env/package.json
+++ b/api/hardhat_env/package.json
@@ -16,9 +16,9 @@
     "@matterlabs/hardhat-zksync-solc": "^1.2.5",
     "@matterlabs/hardhat-zksync-verify": "^1.6.0",
     "@matterlabs/zksync-contracts": "^0.6.1",
-    "@openzeppelin/contracts": "^4.6.0",
+    "@openzeppelin/contracts": "^5.2.0",
     "@openzeppelin/contracts-upgradeable": "^4.6.0",
-    "@chainlink/contracts": "^1.0.0",
+    "@chainlink/contracts": "^1.5.0",
     "@thirdweb-dev/contracts": "^3.11.2"
   }
 }

--- a/api/src/utils/lib.rs
+++ b/api/src/utils/lib.rs
@@ -35,7 +35,7 @@ pub const ALLOWED_NETWORKS: [&str; 2] = ["sepolia", "mainnet"];
 pub const TEMP_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/", "temp/");
 
 pub fn get_file_ext(file_path: &str) -> String {
-    match file_path.split('.').last() {
+    match file_path.split('.').next_back() {
         Some(ext) => ext.to_string(),
         None => {
             debug!("LOG: File extension not found");


### PR DESCRIPTION
Bump the Chainlink and OpenZeppelin versions. Resolves PR #22 