### PR TITLE
feat: add ZKcandy Mainnet

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -106,6 +106,7 @@ fn create_app() -> Rocket<Build> {
 }
 
 #[rocket::main]
+#[allow(clippy::result_large_err)]  
 async fn main() -> Result<(), CoreError> {
     init_logger()?;
 

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -106,7 +106,7 @@ fn create_app() -> Rocket<Build> {
 }
 
 #[rocket::main]
-#[allow(clippy::result_large_err)]  
+#[allow(clippy::result_large_err)]
 async fn main() -> Result<(), CoreError> {
     init_logger()?;
 

--- a/api/src/tracing_log.rs
+++ b/api/src/tracing_log.rs
@@ -100,7 +100,7 @@ pub fn filter_layer(level: LogLevel) -> EnvFilter {
     EnvFilter::try_new(filter_str).expect("filter string must parse")
 }
 
-#[allow(clippy::result_large_err)]  
+#[allow(clippy::result_large_err)]
 pub fn init_logger() -> Result<(), CoreError> {
     // Log all `tracing` events to files prefixed with `debug`.
     // Rolling these files every day

--- a/api/src/tracing_log.rs
+++ b/api/src/tracing_log.rs
@@ -100,6 +100,7 @@ pub fn filter_layer(level: LogLevel) -> EnvFilter {
     EnvFilter::try_new(filter_str).expect("filter string must parse")
 }
 
+#[allow(clippy::result_large_err)]  
 pub fn init_logger() -> Result<(), CoreError> {
     // Log all `tracing` events to files prefixed with `debug`.
     // Rolling these files every day

--- a/plugin/src/index.tsx
+++ b/plugin/src/index.tsx
@@ -11,12 +11,12 @@ import { zkSync, zkSyncSepoliaTestnet } from 'viem/chains'
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { EIP6963Connector, walletConnectProvider } from '@web3modal/wagmi'
-import { sophonTestnet, ZKcandySepoliaTestnet, ZKcandyMainnet, zkLinkNova, zkLinkNovaTestnet } from './utils/custom_chains'
+import { sophonTestnet, ZKcandyMainnet, zkLinkNova, zkLinkNovaTestnet } from './utils/custom_chains'
 
 const projectId: string = import.meta.env.VITE_WALLET_CONNECT_PROJECT_ID // TODO who owns this? make sure matter labs owns this
 
 const zkSyncChains = [zkSyncSepoliaTestnet, zkSync]
-const supportedChains = [ZKcandySepoliaTestnet, ZKcandyMainnet, zkLinkNova, zkLinkNovaTestnet, sophonTestnet]
+const supportedChains = [ZKcandyMainnet, zkLinkNova, zkLinkNovaTestnet, sophonTestnet]
 
 const chains = [...zkSyncChains, ...supportedChains]
 

--- a/plugin/src/index.tsx
+++ b/plugin/src/index.tsx
@@ -11,12 +11,12 @@ import { zkSync, zkSyncSepoliaTestnet } from 'viem/chains'
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { EIP6963Connector, walletConnectProvider } from '@web3modal/wagmi'
-import { sophonTestnet, zkCandySepoliaTestnet, zkLinkNova, zkLinkNovaTestnet } from './utils/custom_chains'
+import { sophonTestnet, ZKcandySepoliaTestnet, ZKcandyMainnet, zkLinkNova, zkLinkNovaTestnet } from './utils/custom_chains'
 
 const projectId: string = import.meta.env.VITE_WALLET_CONNECT_PROJECT_ID // TODO who owns this? make sure matter labs owns this
 
 const zkSyncChains = [zkSyncSepoliaTestnet, zkSync]
-const supportedChains = [zkCandySepoliaTestnet, zkLinkNova, zkLinkNovaTestnet, sophonTestnet]
+const supportedChains = [ZKcandySepoliaTestnet, ZKcandyMainnet, zkLinkNova, zkLinkNovaTestnet, sophonTestnet]
 
 const chains = [...zkSyncChains, ...supportedChains]
 

--- a/plugin/src/utils/custom_chains.ts
+++ b/plugin/src/utils/custom_chains.ts
@@ -1,8 +1,30 @@
 import {defineChain} from 'viem'
 
-export const zkCandySepoliaTestnet = defineChain({
+export const ZKcandyMainnet = defineChain({
+    id: 320,
+    name: 'ZKcandy Mainnet',
+    nativeCurrency: {
+        decimals: 18,
+        name: 'Ether',
+        symbol: 'ETH',
+    },
+    rpcUrls: {
+        default: {
+            http: ['https://rpc.zkcandy.io/'],
+        },
+        public: {
+            http: ['https://rpc.zkcandy.io/'],
+        }
+    },
+    blockExplorers: {
+        default: {name: 'Explorer', url: 'https://explorer.zkcandy.io/'},
+    },
+    network: ''
+})
+
+export const ZKcandySepoliaTestnet = defineChain({
     id: 302,
-    name: 'zkCandy Sepolia Testnet',
+    name: 'ZKcandy Sepolia Testnet',
     nativeCurrency: {
         decimals: 18,
         name: 'Ether',

--- a/plugin/src/utils/custom_chains.ts
+++ b/plugin/src/utils/custom_chains.ts
@@ -22,28 +22,6 @@ export const ZKcandyMainnet = defineChain({
     network: ''
 })
 
-export const ZKcandySepoliaTestnet = defineChain({
-    id: 302,
-    name: 'ZKcandy Sepolia Testnet',
-    nativeCurrency: {
-        decimals: 18,
-        name: 'Ether',
-        symbol: 'ETH',
-    },
-    rpcUrls: {
-        default: {
-            http: ['https://sepolia.rpc.zkcandy.io/'],
-        },
-        public: {
-            http: ['https://sepolia.rpc.zkcandy.io/'],
-        }
-    },
-    blockExplorers: {
-        default: {name: 'Explorer', url: 'https://sepolia.explorer.zkcandy.io/'},
-    },
-    network: ''
-})
-
 export const zkLinkNova = defineChain({
     id: 810180,
     name: 'zkLink Nova',


### PR DESCRIPTION
The ZKcandy Mainnet launched in Q1 2025. To keep up with the ZKsync Era documentation that guides users to use the Remix plugin for EraVM contract deployment, we would like to request support for the ZKcandy Mainnet on the Remix plugin.

This PR also includes an update to the capitalisation of the ZKcandy brand from zkCandy to ZKcandy, reflecting a similar brand update by ZKsync.